### PR TITLE
amplitude only and linear saturation inversions added

### DIFF
--- a/scripts/SMRPI/example_sounding/deep/01_load_data.jl
+++ b/scripts/SMRPI/example_sounding/deep/01_load_data.jl
@@ -1,0 +1,39 @@
+using transD_GP, PyPlot, MAT, DelimitedFiles, Revise
+cd(@__DIR__)
+includet("../../SMRPI.jl")
+includet("../../ProcessingTools.jl")
+using .SMRPI, .ProcessingTools
+## Load the processed data from a GMR FID sounding
+example_fid = matread("../../../../example_data/FID_40ms.mat")
+t = example_fid["time_fid"][:]
+fid_qt = example_fid["coil_1_fid"]
+##
+V0, ϕ = get_sounding_curve(t, fid_qt)
+## params for the sounding - some of these are stored in the MATLAB file
+# but others (e.g. field inclination) are from site info for the survey
+# or separate ASCII files
+q = example_fid["pulse_moment"]
+freq = example_fid["detect_frequency"]
+L = 50
+inclination = 43.9 * π/180 #degrees to radians
+θ = 0 #loop oriented mag. north
+Be = 2π*freq/γh
+resist_data = readdlm("../../../../example_data/1pm_res_profile.txt")
+c = 1 ./ resist_data[2:end,1]
+t = Vector{Float64}(resist_data[2:end-1,2])
+σt = ConductivityModel(c,t)
+## define a depth grid for the modelling and inversion
+zstart = 1.
+extendfrac, dz = 1.028, 1
+zall, znall, zboundaries = transD_GP.setupz(zstart, extendfrac, dz=dz, n=70, showplot=true)
+gcf()
+##
+linearsat = false
+amponly = false
+mult = false
+F = MRSForward_square(L, zboundaries, q[:], inclination, 0, Be, σt)
+sounding = newSMRSounding(V0[:], ϕ[:], F, linearsat=linearsat, amponly=amponly, mult=mult)
+##
+GMR_res = readdlm("../../../../example_data/conductive_earth_inversion_FID_40ms/conductive_earth_inversion_FID_40ms_1d_inversion.txt")
+wc_gmr = GMR_res[1:end-1,4]
+z_gmr = (GMR_res[1:end-1, 1] .+ GMR_res[1:end-1, 1])/2

--- a/scripts/SMRPI/example_sounding/deep/02_make_inversion_opts_nuisance.jl
+++ b/scripts/SMRPI/example_sounding/deep/02_make_inversion_opts_nuisance.jl
@@ -1,0 +1,41 @@
+## make options for the stationary GP
+fileprefix = "SMR_example_"*(linearsat ? "linearsat_" : "logsat_")*
+                            (amponly ? "amponly_" : "")*
+                            (mult ? :"multnoise_" : "")
+K = transD_GP.GP.OrstUhn()
+nmin, nmax = 2, 40
+linearbounds = [.001 0.5]
+fbounds = linearsat ? linearbounds : log10.(linearbounds)
+sdev_pos = [0.05abs(diff([extrema(znall)...])[1])]
+sdev_prop = 0.07*diff(fbounds, dims=2)[:]
+demean = false
+sdev_dc = 0.008*diff(fbounds, dims=2)[:]
+sampledc = true
+xall = permutedims(collect(1:1.0:length(zboundaries)))
+xbounds = permutedims([extrema(xall)...])
+λ, δ = [2], (linearsat ? 0.01 : 0.0001)
+## Initialize a stationary GP using these options
+using Random
+Random.seed!(12)
+opt = transD_GP.OptionsStat(nmin = nmin,
+                        nmax = nmax,
+                        xbounds = xbounds,
+                        fbounds = fbounds,
+                        fdataname = fileprefix,
+                        xall = xall,
+                        λ = λ,
+                        δ = δ,
+                        sdev_prop = sdev_prop,
+                        sdev_pos = sdev_pos,
+                        save_freq = 50,
+                        demean = demean,
+                        sampledc = sampledc,
+                        sdev_dc = sdev_dc,
+                        quasimultid = false,
+                        K = K
+                        )
+
+optn = transD_GP.OptionsNuisance(opt;
+            sdev = [0.005],
+            bounds = [-π π],
+            updatenuisances = true)                        

--- a/scripts/SMRPI/example_sounding/deep/03_run_aem_inversion_s.jl
+++ b/scripts/SMRPI/example_sounding/deep/03_run_aem_inversion_s.jl
@@ -1,0 +1,19 @@
+## set up McMC
+using Distributed
+nsamples, nchains, nchainsatone = 100001, 16, 1
+Tmax = 2.5
+addprocs(nchains)
+@info "workers are $(workers())"
+@everywhere using Distributed
+@everywhere using transD_GP, Revise
+@everywhere includet("../../SMRPI.jl")
+## run McMC
+@time begin
+    if sounding.amponly
+        transD_GP.main(opt, sounding, Tmax=Tmax, nsamples=nsamples, nchains=nchains, nchainsatone=nchainsatone)
+    else    
+        transD_GP.main(opt, optn, sounding, Tmax=Tmax, nsamples=nsamples, nchains=nchains, nchainsatone=nchainsatone)
+    end
+end        
+## close the worker pool
+rmprocs(workers())

--- a/scripts/SMRPI/example_sounding/deep/04_plot_results.jl
+++ b/scripts/SMRPI/example_sounding/deep/04_plot_results.jl
@@ -1,0 +1,32 @@
+using Statistics
+##
+
+close("all")
+transD_GP.getchi2forall(opt)
+ax = gcf().axes;
+# χ² = length(sounding.V0)
+# ax[2].plot(xlim(), [χ², χ²], "--", color="gray")
+# ax[2].set_ylim(χ²-10, χ²+10)
+gcf()
+##
+istothepow = false
+@assert !(linearsat & istothepow)
+opt.xall[:] .= zboundaries
+transD_GP.plot_posterior(sounding, opt, burninfrac=0.5, figsize=(10,6), qp1=0.2, qp2=0.8, nbins=50, istothepow=istothepow, cmappdf="winter",
+    vmaxpc=1.0, pdfnormalize=false, plotmean=false, lwidth=1)
+ax = gcf().axes
+linearsat ? ax[1].set_xlabel("fractional water content") : ax[1].set_xlabel("log\$_{10}\$ water content") 
+linearsat || ax[1].plot(istothepow ? wc_gmr : log10.(wc_gmr), z_gmr, "w-")
+linearsat && ax[1].plot(wc_gmr, z_gmr, "w-")
+gcf()
+##
+# nuisance histograms
+transD_GP.plot_posterior(sounding, optn, burninfrac=0.5, nbins=50)
+gcf()
+
+##
+F = transD_GP.assembleTat1(opt, :U, temperaturenum=1)
+est_σ2 = exp.(1/length(sounding.V0) * F)/(2*length(sounding.V0))
+est_σ = sqrt.(est_σ2)
+
+mean(est_σ)

--- a/src/ForwardModelling.jl
+++ b/src/ForwardModelling.jl
@@ -38,7 +38,7 @@ Parameters:
 Optional parameters:
 - `nrvals`: number of radial points to use to evaluate the horizontal integration of the kernel.
 - `temp`: temperature in Kelvin, affects the magnitude of equilibrium magnetisation.
-- `qwe`: whether to use quadrature with extrapolation (QWE) to evaluate Hankel transforms for the kernel. \
+- `qwe`: whether to use quadrature with extrapolation (QWE) to evaluate Hankel transforms for the kernel. 
 This is slower, but more accurate at shallower depths, than the alternative 801-point digital filter.
 """
 function MRSForward(R::Real, zgrid::AbstractVector{<:Real},

--- a/src/ForwardModelling.jl
+++ b/src/ForwardModelling.jl
@@ -38,7 +38,7 @@ Parameters:
 Optional parameters:
 - `nrvals`: number of radial points to use to evaluate the horizontal integration of the kernel.
 - `temp`: temperature in Kelvin, affects the magnitude of equilibrium magnetisation.
-- `qwe`: whether to use quadrature with extrapolation (QWE) to evaluate Hankel transforms for the kernel. 
+- `qwe`: whether to use quadrature with extrapolation (QWE) to evaluate Hankel transforms for the kernel. \
 This is slower, but more accurate at shallower depths, than the alternative 801-point digital filter.
 """
 function MRSForward(R::Real, zgrid::AbstractVector{<:Real},


### PR DESCRIPTION
scripts/SMRPI/example_sounding/deep have the real data inversions with the flags in `01_load_data.jl` which modify the `fileprefix` in 02_.jl and the plotting scripts in `04_.jl`